### PR TITLE
Performance fixes

### DIFF
--- a/src/main/java/mrriegel/furnus/block/AbstractMachine.java
+++ b/src/main/java/mrriegel/furnus/block/AbstractMachine.java
@@ -49,6 +49,7 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 	protected int speed, effi, slots, bonus, xp, fuel, maxFuel, remainTicks;
 	protected Map<Direction, Mode> input = Maps.newHashMap(), output = Maps.newHashMap(), fuelput = Maps.newHashMap();
 	protected Map<Integer, Integer> progress = Maps.newHashMap();
+	protected ItemStack cachedResult;
 
 	public EnergyStorageExt en = new EnergyStorageExt(64000, Integer.MAX_VALUE - 10, 0);
 
@@ -266,6 +267,26 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 		return false;
 	}
 
+
+	@Override
+	public ItemStack removeStackFromSlot(int index)
+	{
+		this.cachedResult = null;
+		return super.removeStackFromSlot(index);
+	}
+
+	@Override
+	public void setInventorySlotContents(int index, ItemStack stack)
+	{
+		this.cachedResult = null;
+		super.setInventorySlotContents(index, stack);
+	}
+
+	protected boolean hasCachedResult()
+	{
+		return this.cachedResult != null;
+	}
+
 	public abstract ItemStack getResult(ItemStack input);
 
 	public abstract ItemStack getAntiResult(ItemStack input);
@@ -447,9 +468,12 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 				getStackInSlot(slot + 3).grow(itemstack.getCount());
 			}
 			boolean valid;
-			try {
+			try
+			{
 				valid = !getStackInSlot(slot).isItemEqual(getAntiResult(getStackInSlot(slot + 3))) && !StackHelper.equalOreDict(getStackInSlot(slot), getAntiResult(getStackInSlot(slot + 3)));
-			} catch (NullPointerException e) {
+			}
+			catch (NullPointerException e)
+			{
 				valid = true;
 			}
 			if (valid && world.rand.nextInt(100) < bonus * 100 * ConfigHandler.bonusMulti) {

--- a/src/main/java/mrriegel/furnus/block/AbstractMachine.java
+++ b/src/main/java/mrriegel/furnus/block/AbstractMachine.java
@@ -50,6 +50,7 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 	protected Map<Direction, Mode> input = Maps.newHashMap(), output = Maps.newHashMap(), fuelput = Maps.newHashMap();
 	protected Map<Integer, Integer> progress = Maps.newHashMap();
 	protected ItemStack cachedResult;
+	protected ItemStack cachedAntiResult;
 
 	public EnergyStorageExt en = new EnergyStorageExt(64000, Integer.MAX_VALUE - 10, 0);
 
@@ -272,6 +273,8 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 	public ItemStack removeStackFromSlot(int index)
 	{
 		this.cachedResult = null;
+		this.cachedAntiResult = null;
+
 		return super.removeStackFromSlot(index);
 	}
 
@@ -279,12 +282,19 @@ public abstract class AbstractMachine extends CommonTileInventory implements ISi
 	public void setInventorySlotContents(int index, ItemStack stack)
 	{
 		this.cachedResult = null;
+		this.cachedAntiResult = null;
+
 		super.setInventorySlotContents(index, stack);
 	}
 
 	protected boolean hasCachedResult()
 	{
 		return this.cachedResult != null;
+	}
+
+	protected boolean hasCachedAntiResult()
+	{
+		return this.cachedAntiResult != null;
 	}
 
 	public abstract ItemStack getResult(ItemStack input);

--- a/src/main/java/mrriegel/furnus/block/TileFurnus.java
+++ b/src/main/java/mrriegel/furnus/block/TileFurnus.java
@@ -26,8 +26,13 @@ public class TileFurnus extends AbstractMachine {
 	}
 
 	@Override
-	public ItemStack getAntiResult(ItemStack input) {
-		return CrunchHandler.instance().getResult(input);
+	public ItemStack getAntiResult(ItemStack input)
+	{
+		if( !this.hasCachedAntiResult() )
+		{
+			this.cachedAntiResult = CrunchHandler.instance().getResult(input);
+		}
+		return this.cachedAntiResult;
 	}
 
 }

--- a/src/main/java/mrriegel/furnus/block/TileFurnus.java
+++ b/src/main/java/mrriegel/furnus/block/TileFurnus.java
@@ -16,8 +16,13 @@ public class TileFurnus extends AbstractMachine {
 	}
 
 	@Override
-	public ItemStack getResult(ItemStack input) {
-		return FurnaceRecipes.instance().getSmeltingResult(input);
+	public ItemStack getResult(ItemStack input)
+	{
+		if( !this.hasCachedResult() )
+		{
+			this.cachedResult = FurnaceRecipes.instance().getSmeltingResult(input);
+		}
+		return this.cachedResult;
 	}
 
 	@Override

--- a/src/main/java/mrriegel/furnus/block/TilePulvus.java
+++ b/src/main/java/mrriegel/furnus/block/TilePulvus.java
@@ -16,8 +16,13 @@ public class TilePulvus extends AbstractMachine {
 	}
 
 	@Override
-	public ItemStack getResult(ItemStack input) {
-		return CrunchHandler.instance().getResult(input);
+	public ItemStack getResult(ItemStack input)
+	{
+		if( !this.hasCachedResult() )
+		{
+			this.cachedResult = CrunchHandler.instance().getResult(input);
+		}
+		return this.cachedResult;
 	}
 
 	@Override

--- a/src/main/java/mrriegel/furnus/block/TilePulvus.java
+++ b/src/main/java/mrriegel/furnus/block/TilePulvus.java
@@ -26,8 +26,13 @@ public class TilePulvus extends AbstractMachine {
 	}
 
 	@Override
-	public ItemStack getAntiResult(ItemStack input) {
-		return FurnaceRecipes.instance().getSmeltingResult(input);
+	public ItemStack getAntiResult(ItemStack input)
+	{
+		if( !this.hasCachedAntiResult() )
+		{
+			this.cachedAntiResult = FurnaceRecipes.instance().getSmeltingResult(input);
+		}
+		return this.cachedAntiResult;
 	}
 
 }

--- a/src/main/java/mrriegel/furnus/handler/CrunchHandler.java
+++ b/src/main/java/mrriegel/furnus/handler/CrunchHandler.java
@@ -23,16 +23,16 @@ public class CrunchHandler {
 
 	public ItemStack getResult(ItemStack stack) {
 		for (Entry<ItemStack, ItemStack> entry : crushingList.entrySet()) {
-			ItemStack in = entry.getKey().copy();
+			ItemStack in = entry.getKey();
 			if (in.isItemEqual(stack) || (in.getItem() == stack.getItem() && in.getItemDamage() == OreDictionary.WILDCARD_VALUE))
-				return entry.getValue().copy();
+				return entry.getValue();
 		}
 		return ItemStack.EMPTY;
 	}
 
 	public float getExperience(ItemStack stack) {
 		for (Entry<ItemStack, Float> entry : experienceList.entrySet()) {
-			ItemStack in = entry.getKey().copy();
+			ItemStack in = entry.getKey();
 			if (in.isItemEqual(stack) || (in.getItem() == stack.getItem() && in.getItemDamage() == OreDictionary.WILDCARD_VALUE))
 				return entry.getValue();
 		}


### PR DESCRIPTION
We had some performance issues with your mod on our servers, so we go through your code and found two things to fix.

1. Remove copy operation in the "getResult" iteration. We didn't see why this operation is nessesary but it's extrem expensive. It creates a bunch of new objects while every tile on every tick is iterating over the recipes just to discard them a moment later.

2. Caching the recipe result and antiresult until the slot changes. So the server hasn't to iterate over the recipes every tick.

Our timings bevor this fix:
https://timings.aikar.co/?id=109069315d604afba4dba7be744f3af7#timings

Our timings after this fix:
https://timings.aikar.co/?id=342fd8f7a1084530babaa0943072ebd6#timings