### PR TITLE
fixed ArrayOutOfBoundsError crash in ItemUpgrade

### DIFF
--- a/src/main/java/mrriegel/furnus/item/ItemUpgrade.java
+++ b/src/main/java/mrriegel/furnus/item/ItemUpgrade.java
@@ -24,6 +24,7 @@ public class ItemUpgrade extends CommonSubtypeItem {
 
 	@Override
 	public int getItemStackLimit(ItemStack stack) {
+		if(!(stack.getItemDamage()<Upgrade.values().length)) return 8;
 		return ModConfig.maxStacksize.get(Upgrade.values()[stack.getItemDamage()]);
 	}
 

--- a/src/main/java/mrriegel/furnus/item/ItemUpgrade.java
+++ b/src/main/java/mrriegel/furnus/item/ItemUpgrade.java
@@ -24,7 +24,7 @@ public class ItemUpgrade extends CommonSubtypeItem {
 
 	@Override
 	public int getItemStackLimit(ItemStack stack) {
-		if(!(stack.getItemDamage()<Upgrade.values().length)) return 8;
+		if(stack.getItemDamage()>=Upgrade.values().length) return 1;
 		return ModConfig.maxStacksize.get(Upgrade.values()[stack.getItemDamage()]);
 	}
 


### PR DESCRIPTION
fixed https://pastebin.com/KfCcD51s

the method `getItemStaticLimit` assumed the meta was less than the length of the upgrade enum, causing an ArrayOutOfBoundsError